### PR TITLE
use set_dictonary to minimize/check the dictionary

### DIFF
--- a/shortuuid/main.py
+++ b/shortuuid/main.py
@@ -11,9 +11,8 @@ class ShortUUID(object):
         if alphabet is None:
             alphabet = list("23456789ABCDEFGHJKLMNPQRSTUVWXYZ"
                             "abcdefghijkmnopqrstuvwxyz")
-        # Define our alphabet.
-        self._alphabet = alphabet
-        self._alpha_len = len(self._alphabet)
+
+        self.set_alphabet(alphabet)
 
     def _num_to_string(self, number, pad_to_length=None):
         """

--- a/shortuuid/tests.py
+++ b/shortuuid/tests.py
@@ -50,8 +50,8 @@ class LegacyShortUUIDTest(unittest.TestCase):
 
         set_alphabet(backup_alphabet)
 
-        with self.assertRaises(ValueError):
-            ShortUUID("0")
+        make_instance = lambda x: ShortUUID(x)
+        self.assertRaises(ValueError, make_instance, "0")
 
     def test_random(self):
         self.assertEqual(len(random()), 22)

--- a/shortuuid/tests.py
+++ b/shortuuid/tests.py
@@ -50,6 +50,9 @@ class LegacyShortUUIDTest(unittest.TestCase):
 
         set_alphabet(backup_alphabet)
 
+        with self.assertRaises(ValueError):
+            ShortUUID("0")
+
     def test_random(self):
         self.assertEqual(len(random()), 22)
         for i in range(1, 100):


### PR DESCRIPTION
When using ShortUUID(dictionary), an invalid dictionary could be specified.  Given set_dictonary normalizes and verifies that the supplied value, use it rather than setting the values by hand.