### PR TITLE
Include `random` in imports from shortuuid.main

### DIFF
--- a/shortuuid/__init__.py
+++ b/shortuuid/__init__.py
@@ -2,6 +2,7 @@ from shortuuid.main import (
     encode,
     decode,
     uuid,
+    random,
     get_alphabet,
     set_alphabet,
     ShortUUID,


### PR DESCRIPTION
When `random` was added to `main.py` the `__init__.py` file wasn't updated to expose it. Currently, to use, you have to do: `import shortuuid; shortuuid.main.random(24)`. With these changes you can do `import shortuuid; shortuuid.random()`. This better mirrors the behavior of `uuid`, etc.