### PR TITLE
Add py3.4 to tests, and clarify readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
   - "pypy"
 install: # No dependencies.
 script: python setup.py test

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Installation
 
 To install ``shortuuid`` you need:
 
-* Python 2.5 or later in the 2.x line (earlier than 2.5 not tested).
+* Python 2.5 or later in the 2.x line (earlier than 2.6 not tested).
 
 If you have the dependencies, you have multiple options of installation:
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, pypy
+envlist = py26, py27, py32, py33, py34, pypy
 
 [testenv]
 setenv =
@@ -17,6 +17,9 @@ basepython = python3.2
 
 [testenv:py33]
 basepython = python3.3
+
+[testenv:py34]
+basepython = python3.4
 
 [testenv:pypy]
 basepython = pypy


### PR DESCRIPTION
The readme said python <2.5 was not tested, when in fact
python earlier than 2.6 is not tested.